### PR TITLE
Boardクラスの作成

### DIFF
--- a/Doubutsu/Board.pde
+++ b/Doubutsu/Board.pde
@@ -1,0 +1,19 @@
+class Board {
+  BaseArea bArea;
+  InfoArea iArea;
+  MochigomaArea[] mArea = new MochigomaArea[2];
+
+  Board(){
+    bArea = new BaseArea(1,0,4,3);
+    iArea = new InfoArea(1,3,4,1);
+    mArea[0] = new MochigomaArea(0,0,1,4);
+    mArea[1] = new MochigomaArea(5,0,1,4);
+  }
+
+  void draw(){
+    bArea.draw();
+    mArea[0].draw();
+    mArea[1].draw();
+    iArea.draw();
+  }
+}


### PR DESCRIPTION
フィールドとして，AbstractAreaクラスのbArea, iArea及びAbstractAreaクラスの配列mAreaを宣言し、それぞれBaseArea，InfoArea，MochigomaAreaを表す．
MochigomaAreaはLeft,Rightの2つあるため，サイズ2の配列として宣言・初期化した。デフォルトコンストラクタ（引数の無いコンストラクタ）において，bArea, iArea, mArea[0], mArea[1]を初期化する．void draw()メソッドを実装する．さらに、bArea, iArea, mArea[0], mArea[1]で実装されている各draw()を呼び出した．