### PR TITLE
AbstractKomaクラスとKomaStatusクラスの作成

### DIFF
--- a/Doubutsu/AbstractKoma.pde
+++ b/Doubutsu/AbstractKoma.pde
@@ -1,0 +1,26 @@
+abstract class AbstractKoma {
+  String name;
+  int x;
+  int y;
+  int team;//0 or 1
+  KomaStatus kStat;
+
+  AbstractKoma(String name, int x, int y, int team, boolean active) {
+    this.name = name;
+    this.x = x;
+    this.y = y;
+    this.team = team;
+    this.kStat = new KomaStatus(active);
+  }
+
+  void draw() {
+    String komaImage = "";
+    if (this.team==0 && this.kStat.active) komaImage = this.name+"A.png";
+    else if (this.team==1 && this.kStat.active) komaImage = this.name+"B.png";
+    else return;
+
+    PImage img = loadImage(komaImage);
+    image(img, SQUARESIZE*this.x+2, this.y*SQUARESIZE+2, SQUARESIZE-4, SQUARESIZE-4);
+
+  }
+}

--- a/Doubutsu/KomaStatus.pde
+++ b/Doubutsu/KomaStatus.pde
@@ -1,0 +1,11 @@
+class KomaStatus {
+  boolean captured;
+  boolean active;
+  boolean selected;
+
+  KomaStatus(boolean active) {
+    this.active = active;
+    this.captured = false;
+    this.selected = false;
+  }
+}


### PR DESCRIPTION
すべてのコマの持つステータスを保持するクラスとactiveの初期値を引数に取るコンストラクタを持つAbstractKomaクラス，Hiyoko, Kirin等のすべてのコマクラスが継承するクラスである，String型のコマ名(name)，int型の座標(x,y)，int型のteam(Leftが0でRightが1)，KomaStatusクラスのkStatをフィールドとして持つ，raw()メソッドには座標(x,y)の場所に指定されたnameのコマを表示する処理を実装する，以上の条件を満たす
name, x, y, team,activeを引数に取り，初期化するコンストラクタを持つKomaStatusクラスをそれぞれ作成した．