### PR TITLE
Kirinクラスの訂正

### DIFF
--- a/Doubutsu/Kirin.pde
+++ b/Doubutsu/Kirin.pde
@@ -1,0 +1,6 @@
+class Kirin extends AbstractKoma {
+
+  Kirin(String name, int x, int y, int team, boolean active) {
+    super(name, x, y, team, active);
+  }
+}


### PR DESCRIPTION
先ほどKirinクラスのMergeを行った際存在していたKirinクラスのコードがLionクラスのMergeの際，理由は不明だが消えていたため，再度ソースコードを記述した．